### PR TITLE
corrects region subtags in language tags to be BCP-47/IETF compliant

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,17 +13,17 @@ module.exports = {
   'cs':      '„“‚‘',   // Czech
   'da':      '»«›‹',   // Danish
   'nl':      '‘’“”',   // Dutch
-  'en-uk':   '‘’“”',   // English, UK
-  'en-us':   '“”‘’',   // English, US; English, Canada
+  'en-GB':   '‘’“”',   // English, UK
+  'en-US':   '“”‘’',   // English, US; English, Canada
   'eo':      '“”‘’',   // Esperanto
   'et':      '„“«»',   // Estonian
   'fil':     '“”‘’',   // Filipino
   'fi':      '””’’',   // Finnish
   'fr':      '«»“”',   // French
-  'fr-sw':   '«»‹›',   // French, Swiss
+  'fr-CH':   '«»‹›',   // French, Swiss
   'ka':      '„““”',   // Georgian
   'de':      '„“‚‘',   // German
-  'de-sw':   '«»‹›',   // German, Swiss
+  'de-CH':   '«»‹›',   // German, Swiss
   'el':      '«»“”',   // Greek
   'he':      '""\'\'', // Hebrew
   'hu':      '„”»«',   // Hungarian
@@ -31,14 +31,14 @@ module.exports = {
   'id':      '“”‘’',   // Indonesian
   'ga':      '“”‘’',   // Irish
   'it':      '«»“”',   // Italian
-  'it-sw':   '«»‹›',   // Italian, Swiss
+  'it-CH':   '«»‹›',   // Italian, Swiss
   'ko':      '“”‘’',   // Korean
   'lv':      '«»„“',   // Latvian
   'mk':      '„“’‘',   // Macedonian
   'no':      '«»’’',   // Norwegian
   'pl':      '„”«»',   // Polish
-  'pt-br':   '“”‘’',   // Portuguese, Brazil
-  'pt-pl':   '«»“”',   // Portuguese, Portugal
+  'pt-BR':   '“”‘’',   // Portuguese, Brazil
+  'pt-PT':   '«»“”',   // Portuguese, Portugal
   'ro':      '„”«»',   // Romanian
   'ru':      '«»„“',   // Russian
   'sr':      '„”’’',   // Serbian


### PR DESCRIPTION
The language tags used here are in fact those recommended by the W3C and IETF, used by Unicode CLRD, following the BCP-47 spec, which uses subtags for languages, regions and scripts, as they are registered by IANA (http://www.iana.org/assignments/language-subtag-registry/language-subtag-registry), which, by principle, uses a combination of the codes in ISO-639-1 and ISO-639-3. I have corrected the erroneous region subtags to match the region tags for the United Kingdom (`GB`), Switzerland (`CH`), Portugal (`PT`).
